### PR TITLE
Fix _action_to_direction usage

### DIFF
--- a/template/{{environment_name}}/envs/grid_world.py
+++ b/template/{{environment_name}}/envs/grid_world.py
@@ -38,10 +38,10 @@ class GridWorldEnv(gym.Env):
         i.e. 0 corresponds to "right", 1 to "up" etc.
         """
         self._action_to_direction = {
-            Actions.right: np.array([1, 0]),
-            Actions.up: np.array([0, 1]),
-            Actions.left: np.array([-1, 0]),
-            Actions.down: np.array([0, -1]),
+            Actions.right.value: np.array([1, 0]),
+            Actions.up.value: np.array([0, 1]),
+            Actions.left.value: np.array([-1, 0]),
+            Actions.down.value: np.array([0, -1]),
         }
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]


### PR DESCRIPTION
# Description

To use the _action_to_direction dict, we need to first convert the numerical action (0, 1, 2, 3) to an Enum.

Fixes https://github.com/Farama-Foundation/gymnasium-env-template/issues/3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)