### PR TITLE
Fix wheel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -e .
+          pip list
 
       - name: Run tests
         run: pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["template"]
+include = ["*.py"]
+exclude = ["test*"]
 
 [project]
 name = "gymnasium-env-template"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-include = ["*.py"]
-exclude = ["test*"]
+packages = ["template"]
 
 [project]
 name = "gymnasium-env-template"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
   "copier",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["template"]
+
 [project]
 name = "gymnasium-env-template"
 version = "0.0.1"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -2,11 +2,14 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["{{ environment_name }}"]
+
 [project]
 name = "{{ environment_name }}"
 version = "0.0.1"
 dependencies = [
   "gymnasium",
-  "pygame==2.1.3",
+  "pygame>=2.1.3",
   "pre-commit",
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,7 @@ class GenerateTemplate:
             dst_path=str(TEMPLATE_LOC),
             data=template_vars,
             cleanup_on_error=True,
+            vcs_ref="HEAD",
             # defaults=True,
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,7 @@ class GenerateTemplate:
             dst_path=str(TEMPLATE_LOC),
             data=template_vars,
             cleanup_on_error=True,
-            vcs_ref="HEAD",
+            # vcs_ref="HEAD",
             # defaults=True,
         )
 


### PR DESCRIPTION
# Description

This PR should fix some breaking changes introduced by the Hatch/Hatchling build backend (https://github.com/pypa/hatch/pull/1089) which now requires to explicitly specify the files/directories that are included in building the Python wheel. Fixed both in the main package and in the templated package.

Related to https://github.com/Farama-Foundation/gymnasium-env-template/pull/4#issuecomment-1876429385, should fix https://github.com/Farama-Foundation/gymnasium-env-template/actions/runs/7396199598/job/20120848417.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes